### PR TITLE
Allow specifying the destination directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Optional
   - VERSION incorrectly specified with `-i`
   - Download URL Format Changed on terraform Website
 - Determines Install Destination
+  - The destination can be specified with `-c` option, or passing `TF_INSTALL_DIR` environment variable
+  - The default is `/usr/local/bin` if it is writable, or with `-a`
+  - Otherwise the user is prompted for options
   - Performed before Download/Install Process in case user selects `abort`
 - Installation Process
   - Download, Download SHA, Verify SHA of zip, Extract, Install, Cleanup and Display Results

--- a/terraform-install.sh
+++ b/terraform-install.sh
@@ -44,7 +44,7 @@ usage() {
   [[ "$1" ]] && echo -e "Download and Install Terraform - Latest Version unless '-i' specified\n"
   echo -e "usage: ${scriptname} [-i VERSION] [-a] [-c] [-h] [-v]"
   echo -e "     -i VERSION\t: specify version to install in format '0.11.8' (OPTIONAL)"
-  echo -e "     -a\t\t: automatically use sudo to install to /usr/local/bin"
+  echo -e "     -a\t\t: automatically use sudo to install to /usr/local/bin (or \$TF_INSTALL_DIR)"
   echo -e "     -c\t\t: leave binary in working directory (for CI/DevOps use)"
   echo -e "     -h\t\t: help"
   echo -e "     -v\t\t: display ${scriptname} version"
@@ -148,6 +148,10 @@ fi
 # DETERMINE DESTINATION
 if [[ "$cwdInstall" ]]; then
   BINDIR=$(pwd)
+elif [[ -n "$TF_INSTALL_DIR" ]]; then
+  BINDIR="$TF_INSTALL_DIR"
+  CMDPREFIX="${sudoInstall:+sudo }"
+  STREAMLINED=true
 elif [[ -w "/usr/local/bin" ]]; then
   BINDIR="/usr/local/bin"
   CMDPREFIX=""


### PR DESCRIPTION
Without the `-c` flag, allow the user to pass the destination directory with ~`DEST`~ `TF_INSTALL_DIR` environment variable. The `-a` flag can also be used for sudo.